### PR TITLE
Fix login modal in dashboard page

### DIFF
--- a/__tests__/pages/dashboard.test.tsx
+++ b/__tests__/pages/dashboard.test.tsx
@@ -74,11 +74,12 @@ describe('Dashboard', () => {
     });
 
     it('shows login modal if not logged in', () => {
+        const push = jest.fn();
+        mockUseRouter.mockReturnValue({ push });
         mockUseAuthenticated.mockReturnValue({
             isLoggedIn: false,
             userData: undefined,
         });
-        mockUseRouter.mockReturnValue({});
         mockUseGetUrlsQuery.mockReturnValue({
             data: undefined,
             isLoading: false,
@@ -92,6 +93,7 @@ describe('Dashboard', () => {
         expect(screen.getByText('Login to view your URLs and create new ones')).toBeInTheDocument();
         const closeButton = screen.getByTestId('close-modal');
         closeButton.click();
+        expect(push).toHaveBeenCalledWith('/');
     });
 
     it('shows no urls found message if no urls found', () => {

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -1,3 +1,5 @@
+import { useRouter } from 'next/router';
+
 import Button from '@/components/Button';
 import { DashboardLayout } from '@/components/Dashboard/dashboard-layout';
 import NoUrlFound from '@/components/Dashboard/NoUrlFound';
@@ -11,6 +13,7 @@ import useToast from '@/hooks/useToast';
 import { useGetUrlsQuery } from '@/services/api';
 
 const Dashboard = () => {
+    const router = useRouter();
     const { showToast, toasts } = useToast();
     const { isLoggedIn, userData } = useAuthenticated();
     const { data, isLoading, isError } = useGetUrlsQuery({ enabled: !!userData?.data?.id });
@@ -25,11 +28,15 @@ const Dashboard = () => {
         window.location.reload();
     };
 
+    const handleLoginModalClose = () => {
+        router.push('/');
+    };
+
     if (!isLoggedIn) {
         return (
             <Layout title="Dashboard | URL Shortener">
                 <div className="min-h-[calc(100vh-145px)]">
-                    <LoginModal onClose={() => void 0}>
+                    <LoginModal onClose={handleLoginModalClose}>
                         <p className="text-black text-center mb-4">Login to view your URLs and create new ones</p>
                     </LoginModal>
                 </div>


### PR DESCRIPTION
## Issue Ticket Number

-  closes #148

## Description

Users now can close the login modal from the dashboard when they are not login

**Breaking Changes**

-   [ ] Yes
-   [x] No

_If your feature introduces breaking changes or if something is missing, please mention the related issue tickets._

**Development Tested?**

-   [x] Yes
-   [ ] No

_Confirm whether the changes have been tested locally during development._

**Tested in Staging?**

-   [ ] Yes
-   [x] No

_Indicate whether the changes have been tested in the staging environment._

**Under Feature Flag**

-   [ ] Yes
-   [x] No

_Specify if the changes are currently under a feature flag._

**Database Changes**

-   [ ] Yes
-   [x] No

_Indicate whether the changes include modifications to the database._




### Screenshots
Before


https://github.com/user-attachments/assets/aefd7834-a99e-4700-81ed-0be23845885b


After


https://github.com/user-attachments/assets/c703eb09-bd0e-46d3-b2a1-3b13510eb188


## Test Coverage

![image](https://github.com/user-attachments/assets/6faae39f-2522-473e-b1bb-cd0db334e982)

## Additional Notes

Include any additional notes, considerations, or explanations that might be helpful for reviewers.
